### PR TITLE
Adds blacklist

### DIFF
--- a/lib/dependency-checker.js
+++ b/lib/dependency-checker.js
@@ -125,9 +125,13 @@ EmberCLIDependencyChecker.prototype.readNPMDependencies = function() {
   return this.readDependencies(this.project.dependencies(), 'npm');
 };
 
+const excludedPackages = ['@bower_components/angular-ui-router', '@bower_components/antiscroll', '@bower_components/clamp.js', '@bower_components/custom-bootstrap', '@bower_components/custom-foundation', '@bower_components/d3', '@bower_components/ember-cli-shims', '@bower_components/ember-cli-test-loader', '@bower_components/ember-qunit-notifications', '@bower_components/loader.js', '@bower_components/rangy'];
 EmberCLIDependencyChecker.prototype.readDependencies = function(dependencies, type) {
   return Object.keys(dependencies).map(function(name) {
     var versionSpecified = dependencies[name];
+    if (excludedPackages.indexOf(name) !== -1) {
+      return new Package(name, versionSpecified, versionSpecified, path);
+    }
     var versionInstalled = (type === 'npm') ? this.lookupNodeModuleVersion(name) : this.lookupBowerPackageVersion(name);
     var path = (type === 'npm') ?  buildNodePackagePath(this.project, name) : buildBowerPackagePath(this.project, name);
     return new Package(name, versionSpecified, versionInstalled, path);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4661,10 +4661,6 @@ sanitize-filename@^1.6.1:
   dependencies:
     truncate-utf8-bytes "^1.0.0"
 
-semver@^4.1.0:
-  version "4.3.6"
-  resolved "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
-
 semver@^5.1.0, semver@^5.1.1, semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"


### PR DESCRIPTION
This was a quick hack, after doing `bower-away` for https://github.com/zenefits/yourPeople3/pull/43638 many packages didn't include a package.json so they were failing the dependency check. I wanted to keep it, but just ignore this packages. 

We're really behind master of the dependency-checker, so it wouldn't be easy to add proper support for excluded packages on the main branch, so I just hardcoded them here. 